### PR TITLE
Update admin view so that people can be easily asigned to projects

### DIFF
--- a/rppl/people/admin.py
+++ b/rppl/people/admin.py
@@ -1,14 +1,33 @@
 from django.contrib import admin
 from models import *
 
-admin.site.register(Person)
 admin.site.register(Link)
 admin.site.register(Organization)
-admin.site.register(Project)
-admin.site.register(Edition)
 admin.site.register(Role)
 
 class PRAdmin(admin.ModelAdmin):
     list_display = ('person', 'edition', 'role')
 
+class PersonAdmin(admin.ModelAdmin):
+    list_display = ('username', 'name', 'email', 'is_active', 'is_staff')
+
+class PersonRoleInlineAdmin(admin.StackedInline):
+    model = PersonRole
+    extra = 0
+
+class EditionAdmin(admin.ModelAdmin):
+    list_display = ('project', 'name')
+    inlines = [PersonRoleInlineAdmin, ]
+
+class EditionInlineAdmin(admin.StackedInline):
+    model = Edition
+    extra = 0
+
+class ProjectAdmin(admin.ModelAdmin):
+    list_display = ('name', 'url')
+    inlines = [EditionInlineAdmin, ]
+
 admin.site.register(PersonRole, PRAdmin)
+admin.site.register(Person, PersonAdmin)
+admin.site.register(Project, ProjectAdmin)
+admin.site.register(Edition, EditionAdmin)


### PR DESCRIPTION
## Need

``` gherkin
In order to easily assign people to projects
As a ROSEdu team member
I want to have a nice admin view
```
## Deliverables

Admin view that allows easy project creation and assignment.
## Solution
- Use only django builtins
#### TODO
- [x] Use builtins to add more information in the admin page
## Notes

While looking for solutions to this found out that a set of features that Django Admin has are enough for what we need right now.
