### PR TITLE
Debug mode on the server

### DIFF
--- a/rppl/settings_production.py
+++ b/rppl/settings_production.py
@@ -2,3 +2,4 @@ from settings import *
 
 # This file includes settings that should be overridden in production.
 DEBUG = False
+TEMPLATE_DEBUG = DEBUG


### PR DESCRIPTION
You really don't want to leave debug mode enabled on the server, it's a security risk:
https://docs.djangoproject.com/en/dev/ref/settings/#debug
