### PR TITLE
Alphabetical order that includes romanian characters

### DIFF
--- a/rppl/resources/js/grid-search.js
+++ b/rppl/resources/js/grid-search.js
@@ -49,7 +49,7 @@ var highlightName = function () {
             }
         });
 
-alphabet.sort(function sortCompare(a,b){return a.localeCompare(b);});
+alphabet.sort(function (a,b){return a.localeCompare(b);});
 
 alphabet.forEach(function(e) {
 	var li = document.createElement('li');


### PR DESCRIPTION
#### Need

``` gherkin
In order to see the letters in alphabetical order including Romanian characters.
As a user.
```
#### Deliverables
- [ ] the special characters will displayed in the correct order.
#### Prerequisites
- JavaScript
- grid_search.js
#### Solution

Define a sorting method.
